### PR TITLE
Upgrade go-mcp to v0.2.24 to support MCP protocol version 2025-06-18

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Config file example
 
 ### stdio
 The stdio transport is particularly useful for:
-- Claude Desktop which does not officially support SSE yet. See https://github.com/orgs/modelcontextprotocol/discussions/16
 - Direct piping to/from other processes
 - Integration with CLI tools
 - Testing in environments without HTTP

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.23.8
 
 require (
-	github.com/ThinkInAIXYZ/go-mcp v0.1.14
+	github.com/ThinkInAIXYZ/go-mcp v0.2.24
 	github.com/openai/openai-go v0.1.0-beta.10
 	github.com/robfig/cron/v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ThinkInAIXYZ/go-mcp v0.1.14 h1:CY0O0KClgOgRZrXSSyqX8vAj9gzuu2LULvVY2F6yCaU=
-github.com/ThinkInAIXYZ/go-mcp v0.1.14/go.mod h1:KnUWUymko7rmOgzvIjxwX0uB9oiJeLF/Q3W9cRt8fVg=
+github.com/ThinkInAIXYZ/go-mcp v0.2.24 h1:NLMshD8Dgrc7Di0JDLM+KhrETmu1V9tIgrJsBtyqe10=
+github.com/ThinkInAIXYZ/go-mcp v0.2.24/go.mod h1:KnUWUymko7rmOgzvIjxwX0uB9oiJeLF/Q3W9cRt8fVg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/openai/openai-go v0.1.0-beta.10 h1:CknhGXe8aXQMRuqg255PFnWzgRY9nEryMxoNIBBM9tU=

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -47,7 +47,7 @@ func createSuccessResponse(message string) (*protocol.CallToolResult, error) {
 
 	return &protocol.CallToolResult{
 		Content: []protocol.Content{
-			protocol.TextContent{
+			&protocol.TextContent{
 				Type: "text",
 				Text: string(responseJSON),
 			},
@@ -71,7 +71,7 @@ func createTaskResponse(task *model.Task) (*protocol.CallToolResult, error) {
 
 	return &protocol.CallToolResult{
 		Content: []protocol.Content{
-			protocol.TextContent{
+			&protocol.TextContent{
 				Type: "text",
 				Text: string(taskJSON),
 			},
@@ -88,7 +88,7 @@ func createTasksResponse(tasks []*model.Task) (*protocol.CallToolResult, error) 
 
 	return &protocol.CallToolResult{
 		Content: []protocol.Content{
-			protocol.TextContent{
+			&protocol.TextContent{
 				Type: "text",
 				Text: string(tasksJSON),
 			},

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -239,7 +239,7 @@ func (s *MCPServer) Stop() error {
 }
 
 // handleListTasks lists all tasks
-func (s *MCPServer) handleListTasks(_ *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
+func (s *MCPServer) handleListTasks(_ context.Context, _ *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	s.logger.Debugf("Handling list_tasks request")
 
 	// Get all tasks
@@ -249,7 +249,7 @@ func (s *MCPServer) handleListTasks(_ *protocol.CallToolRequest) (*protocol.Call
 }
 
 // handleGetTask gets a specific task by ID
-func (s *MCPServer) handleGetTask(request *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
+func (s *MCPServer) handleGetTask(_ context.Context, request *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	// Extract task ID
 	taskID, err := extractTaskIDParam(request)
 	if err != nil {
@@ -268,7 +268,7 @@ func (s *MCPServer) handleGetTask(request *protocol.CallToolRequest) (*protocol.
 }
 
 // handleAddTask adds a new shell command task
-func (s *MCPServer) handleAddTask(request *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
+func (s *MCPServer) handleAddTask(_ context.Context, request *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	// Extract parameters
 	var params TaskParams
 
@@ -296,7 +296,7 @@ func (s *MCPServer) handleAddTask(request *protocol.CallToolRequest) (*protocol.
 	return createTaskResponse(task)
 }
 
-func (s *MCPServer) handleAddAITask(request *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
+func (s *MCPServer) handleAddAITask(_ context.Context, request *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	// Extract parameters
 	var params AITaskParams
 
@@ -344,7 +344,7 @@ func createBaseTask(name, schedule, description string, enabled bool) *model.Tas
 }
 
 // handleUpdateTask updates an existing task
-func (s *MCPServer) handleUpdateTask(request *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
+func (s *MCPServer) handleUpdateTask(_ context.Context, request *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	// Extract parameters
 	var params AITaskParams
 
@@ -415,7 +415,7 @@ func updateTaskFields(task *model.Task, params AITaskParams, rawJSON []byte) {
 }
 
 // handleRemoveTask removes a task
-func (s *MCPServer) handleRemoveTask(request *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
+func (s *MCPServer) handleRemoveTask(_ context.Context, request *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	// Extract task ID
 	taskID, err := extractTaskIDParam(request)
 	if err != nil {
@@ -433,7 +433,7 @@ func (s *MCPServer) handleRemoveTask(request *protocol.CallToolRequest) (*protoc
 }
 
 // handleEnableTask enables a task
-func (s *MCPServer) handleEnableTask(request *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
+func (s *MCPServer) handleEnableTask(_ context.Context, request *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	// Extract task ID
 	taskID, err := extractTaskIDParam(request)
 	if err != nil {
@@ -457,7 +457,7 @@ func (s *MCPServer) handleEnableTask(request *protocol.CallToolRequest) (*protoc
 }
 
 // handleDisableTask disables a task
-func (s *MCPServer) handleDisableTask(request *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
+func (s *MCPServer) handleDisableTask(_ context.Context, request *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	// Extract task ID
 	taskID, err := extractTaskIDParam(request)
 	if err != nil {

--- a/internal/server/server_ai_test.go
+++ b/internal/server/server_ai_test.go
@@ -2,6 +2,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -65,7 +66,7 @@ func TestHandleAddAITask_AI(t *testing.T) {
 	}
 
 	// Call the handler
-	result, err := server.handleAddAITask(validRequest)
+	result, err := server.handleAddAITask(context.Background(),validRequest)
 	if err != nil {
 		t.Fatalf("Valid request should not fail: %v", err)
 	}
@@ -86,7 +87,7 @@ func TestHandleAddAITask_AI(t *testing.T) {
 	}
 
 	// Call the handler
-	result, err = server.handleAddAITask(invalidRequest)
+	result, err = server.handleAddAITask(context.Background(),invalidRequest)
 	if err == nil {
 		t.Fatal("Invalid request should fail")
 	}
@@ -106,7 +107,7 @@ func TestHandleAddAITask_AI(t *testing.T) {
 	}
 
 	// Call the handler
-	result, err = server.handleAddAITask(missingNameRequest)
+	result, err = server.handleAddAITask(context.Background(),missingNameRequest)
 	if err == nil {
 		t.Fatal("Request with missing name should fail")
 	}
@@ -126,7 +127,7 @@ func TestHandleAddAITask_AI(t *testing.T) {
 	}
 
 	// Call the handler
-	result, err = server.handleAddAITask(missingScheduleRequest)
+	result, err = server.handleAddAITask(context.Background(),missingScheduleRequest)
 	if err == nil {
 		t.Fatal("Request with missing schedule should fail")
 	}
@@ -172,7 +173,7 @@ func TestUpdateAITask_AI(t *testing.T) {
 	}
 
 	// Call the handler
-	result, err := server.handleUpdateTask(updateRequest)
+	result, err := server.handleUpdateTask(context.Background(),updateRequest)
 	if err != nil {
 		t.Fatalf("Valid update should not fail: %v", err)
 	}
@@ -204,7 +205,7 @@ func TestUpdateAITask_AI(t *testing.T) {
 	}
 
 	// Call the handler
-	result, err = server.handleUpdateTask(multiUpdateRequest)
+	result, err = server.handleUpdateTask(context.Background(),multiUpdateRequest)
 	if err != nil {
 		t.Fatalf("Valid multi-update should not fail: %v", err)
 	}
@@ -269,7 +270,7 @@ func TestConvertTaskTypes_AI(t *testing.T) {
 	}
 
 	// Call the handler
-	result, err := server.handleUpdateTask(updateRequest)
+	result, err := server.handleUpdateTask(context.Background(),updateRequest)
 	if err != nil {
 		t.Fatalf("Valid conversion should not fail: %v", err)
 	}
@@ -323,7 +324,7 @@ func TestConvertTaskTypes_AI(t *testing.T) {
 	}
 
 	// Call the handler
-	result, err = server.handleUpdateTask(convertRequest)
+	result, err = server.handleUpdateTask(context.Background(),convertRequest)
 	if err != nil {
 		t.Fatalf("Valid conversion should not fail: %v", err)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -206,7 +206,7 @@ func TestTaskCreationTimeFields(t *testing.T) {
 		}`),
 	}
 
-	result, err := server.handleAddTask(mockRequest)
+	result, err := server.handleAddTask(context.Background(), mockRequest)
 	if err != nil {
 		t.Fatalf("handleAddTask failed: %v", err)
 	}
@@ -346,7 +346,7 @@ func TestTaskTypeHandling(t *testing.T) {
 		}`),
 	}
 
-	result, err := server.handleAddTask(defaultTypeRequest)
+	result, err := server.handleAddTask(context.Background(), defaultTypeRequest)
 	if err != nil {
 		t.Fatalf("handleAddTask failed for default type: %v", err)
 	}
@@ -366,7 +366,7 @@ func TestTaskTypeHandling(t *testing.T) {
 		}`),
 	}
 
-	result, err = server.handleAddAITask(aiTypeRequest)
+	result, err = server.handleAddAITask(context.Background(), aiTypeRequest)
 	if err != nil {
 		t.Fatalf("handleAddAITask failed for AI type: %v", err)
 	}
@@ -386,7 +386,7 @@ func TestTaskTypeHandling(t *testing.T) {
 		}`),
 	}
 
-	result, err = server.handleAddAITask(aiTypeUpperRequest)
+	result, err = server.handleAddAITask(context.Background(), aiTypeUpperRequest)
 	if err != nil {
 		t.Fatalf("handleAddAITask failed for AI uppercase type: %v", err)
 	}
@@ -444,7 +444,7 @@ func TestTaskTypeHandling(t *testing.T) {
 		}`, defaultTypeTask.ID)),
 	}
 
-	result, err = server.handleUpdateTask(updateTypeRequest)
+	result, err = server.handleUpdateTask(context.Background(), updateTypeRequest)
 	if err != nil {
 		t.Fatalf("handleUpdateTask failed for type update: %v", err)
 	}
@@ -469,7 +469,7 @@ func TestTaskTypeHandling(t *testing.T) {
 		}`, aiLowerTypeTask.ID)),
 	}
 
-	result, err = server.handleUpdateTask(updateTypeBackRequest)
+	result, err = server.handleUpdateTask(context.Background(), updateTypeBackRequest)
 	if err != nil {
 		t.Fatalf("handleUpdateTask failed for reverse type update: %v", err)
 	}

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -2,6 +2,8 @@
 package server
 
 import (
+	"context"
+
 	"github.com/ThinkInAIXYZ/go-mcp/protocol"
 	"github.com/ThinkInAIXYZ/go-mcp/server"
 )
@@ -15,7 +17,7 @@ type ToolDefinition struct {
 	Description string
 
 	// Handler is the function that will be called when the tool is invoked
-	Handler func(*protocol.CallToolRequest) (*protocol.CallToolResult, error)
+	Handler func(context.Context, *protocol.CallToolRequest) (*protocol.CallToolResult, error)
 
 	// Parameters is the parameter schema for the tool (can be a struct)
 	Parameters interface{}


### PR DESCRIPTION
## Summary

- Upgraded `github.com/ThinkInAIXYZ/go-mcp` from `v0.1.14` to `v0.2.24` to support MCP protocol version `2025-06-18`
- Adapted to breaking API changes: pointer `TextContent`, context-aware tool handlers
- Removed outdated note about Claude Desktop SSE support in README

Fixes #4

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `go test ./...` all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)