### PR TITLE
Add Google Gemini to Chat Completions gateway list

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,7 +23,10 @@ const (
 // ChatCompletionsOnlyGateways lists hostnames of API proxies that support only
 // the Chat Completions API (not the Responses API). When the configured base
 // URL matches one of these, the agent falls back to the Chat Completions provider.
-var ChatCompletionsOnlyGateways = []string{"api.kilo.ai"}
+var ChatCompletionsOnlyGateways = []string{
+	"api.kilo.ai",
+	"generativelanguage.googleapis.com",
+}
 
 // IsChatCompletionsGateway returns true if baseURL points to a known proxy
 // that only supports Chat Completions.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -130,6 +130,7 @@ func TestIsChatCompletionsGateway(t *testing.T) {
 		{"direct openai", "https://api.openai.com/v1", false},
 		{"kilo gateway", "https://api.kilo.ai/api/gateway", true},
 		{"kilo with path", "https://api.kilo.ai/v1", true},
+		{"gemini", "https://generativelanguage.googleapis.com/v1beta/openai", true},
 		{"ollama", "http://localhost:11434/v1", false},
 		{"groq", "https://api.groq.com/openai/v1", false},
 	}


### PR DESCRIPTION
## Summary
- Add `generativelanguage.googleapis.com` to `ChatCompletionsOnlyGateways` so Gemini's OpenAI-compatible endpoint uses the Chat Completions provider instead of the Responses API (which returns 404)
- Add test case for the Gemini gateway URL

Fixes #11

## Test plan
- [x] `go build ./...` -- compiles cleanly
- [x] `go test ./internal/config/ -run TestIsChatCompletionsGateway -v` -- all cases pass including new Gemini case
- [x] `go tool golangci-lint run` -- no lint issues