### PR TITLE
Make run_task synchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ The server exposes several tools through the MCP protocol:
 4. `add_ai_task` - Adds a new AI (LLM) task with a prompt (provide `schedule` for recurring, or omit for on-demand)
 5. `update_task` - Updates an existing task
 6. `remove_task` - Removes a task by ID
-7. `run_task` - Immediately executes a task by ID (for on-demand tasks or ad-hoc runs of scheduled tasks)
+7. `run_task` - Executes a task by ID, waits for completion, and returns the result (for on-demand tasks or ad-hoc runs of scheduled tasks)
 8. `enable_task` - Enables a task so it runs on its schedule or can be triggered via `run_task`
 9. `disable_task` - Disables a task so it stops running and cannot be triggered
 10. `get_task_result` - Gets execution results for a task (latest by default, or recent history with `limit`)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -42,7 +42,7 @@ MCP_CRON_ENABLE_ANTHROPIC_TESTS=true go test ./...
 | `TestIntegration_ErrorCases` | Table-driven tests for missing fields and not-found errors |
 | `TestIntegration_MultipleTasksIsolation` | Executing one task does not affect other tasks' results |
 | `TestIntegration_OnDemandTask` | Create and execute an on-demand task (no schedule) |
-| `TestIntegration_RunTask` | run_task handler: disabled task error, enable + run, not-found, missing ID |
+| `TestIntegration_RunTask` | run_task handler: disabled task error, enable + sync run with result, not-found, missing ID |
 | `TestIntegration_OnDemandAITask` | Create an on-demand AI task and verify type/schedule |
 | `TestIntegration_OnDemandRunTaskLifecycle` | Full on-demand lifecycle via poll loop (shell + AI subtests) |
 | `TestIntegration_ScheduledRunTaskResumesSchedule` | run_task on a scheduled task resumes its cron schedule after execution (shell + AI subtests) |

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -242,6 +242,8 @@ func mustDisableTask(t *testing.T, srv *MCPServer, id string) model.Task {
 
 // waitForResult polls get_task_result until a completed result (non-empty output
 // or non-zero exit code) appears or the deadline expires.
+//
+//nolint:unused // kept as a test utility for future use
 func waitForResult(t *testing.T, srv *MCPServer, taskID string, timeout time.Duration) model.Result {
 	t.Helper()
 	ctx := context.Background()

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -241,7 +241,6 @@ func mustDisableTask(t *testing.T, srv *MCPServer, id string) model.Task {
 }
 
 
-
 // waitForNResults polls the result store until at least n results exist for
 // the given task, or the deadline expires.
 func waitForNResults(t *testing.T, srv *MCPServer, taskID string, n int, timeout time.Duration) []*model.Result {

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -240,32 +240,7 @@ func mustDisableTask(t *testing.T, srv *MCPServer, id string) model.Task {
 	return task
 }
 
-// waitForResult polls get_task_result until a completed result (non-empty output
-// or non-zero exit code) appears or the deadline expires.
-//
-//nolint:unused // kept as a test utility for future use
-func waitForResult(t *testing.T, srv *MCPServer, taskID string, timeout time.Duration) model.Result {
-	t.Helper()
-	ctx := context.Background()
-	deadline := time.After(timeout)
-	for {
-		select {
-		case <-deadline:
-			t.Fatalf("no completed result for task %s within %s", taskID, timeout)
-		default:
-		}
-		req := makeRequest(t, TaskResultParams{ID: taskID})
-		res, err := srv.handleGetTaskResult(ctx, req)
-		if err == nil {
-			var result model.Result
-			parseResponse(t, res, &result)
-			if result.Output != "" || result.Error != "" {
-				return result
-			}
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-}
+
 
 // waitForNResults polls the result store until at least n results exist for
 // the given task, or the deadline expires.

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -626,7 +626,10 @@ func TestIntegration_OnDemandTask(t *testing.T) {
 
 // TestIntegration_RunTask tests the run_task handler.
 func TestIntegration_RunTask(t *testing.T) {
-	srv := createIntegrationTestServer(t)
+	srv := createIntegrationTestServer(t, integrationOpts{
+		withStore:    true,
+		pollInterval: 200 * time.Millisecond,
+	})
 
 	task := mustAddShellTask(t, srv, TaskParams{
 		Name:    "run-task-test",
@@ -643,10 +646,18 @@ func TestIntegration_RunTask(t *testing.T) {
 
 	mustEnableTask(t, srv, task.ID)
 
-	// run_task on an enabled task should succeed
-	_, err = srv.handleRunTask(ctx, makeRequest(t, TaskIDParams{ID: task.ID}))
+	// run_task on an enabled task should return the actual result
+	res, err := srv.handleRunTask(ctx, makeRequest(t, TaskIDParams{ID: task.ID}))
 	if err != nil {
 		t.Fatalf("handleRunTask failed: %v", err)
+	}
+	text := res.Content[0].(*mcp.TextContent).Text
+	var result model.Result
+	if err := json.Unmarshal([]byte(text), &result); err != nil {
+		t.Fatalf("failed to parse result JSON: %v", err)
+	}
+	if !strings.Contains(result.Output, "triggered") {
+		t.Fatalf("expected output to contain 'triggered', got: %s", result.Output)
 	}
 
 	// run_task on nonexistent task should fail
@@ -748,16 +759,9 @@ func TestIntegration_OnDemandRunTaskLifecycle(t *testing.T) {
 			}
 
 			resp := mustRunTask(t, srv, task.ID)
-			if resp["success"] != true {
-				t.Errorf("expected success=true, got %v", resp["success"])
-			}
-
-			result := waitForResult(t, srv, task.ID, tc.timeout)
-			if result.ExitCode != 0 {
-				t.Errorf("expected exit_code 0, got %d (error: %s)", result.ExitCode, result.Error)
-			}
-			if !strings.Contains(result.Output, tc.wantOutput) {
-				t.Errorf("expected output to contain %q, got %q", tc.wantOutput, result.Output)
+			output, _ := resp["output"].(string)
+			if !strings.Contains(output, tc.wantOutput) {
+				t.Errorf("expected output to contain %q, got %q", tc.wantOutput, output)
 			}
 
 			// Verify task went back to idle (NextRun cleared)
@@ -838,20 +842,10 @@ func TestIntegration_ScheduledRunTaskResumesSchedule(t *testing.T) {
 				t.Fatalf("expected NextRun in the future, got %v", originalNextRun)
 			}
 
-			mustRunTask(t, srv, task.ID)
-
-			// Verify NextRun was moved to approximately now
-			triggeredTask := mustGetTask(t, srv, task.ID)
-			if triggeredTask.NextRun.After(time.Now().Add(2 * time.Second)) {
-				t.Errorf("expected NextRun ~now after run_task, got %v", triggeredTask.NextRun)
-			}
-
-			result := waitForResult(t, srv, task.ID, tc.timeout)
-			if result.ExitCode != 0 {
-				t.Errorf("expected exit_code 0, got %d (error: %s)", result.ExitCode, result.Error)
-			}
-			if !strings.Contains(result.Output, tc.wantOutput) {
-				t.Errorf("expected output to contain %q, got %q", tc.wantOutput, result.Output)
+			resp := mustRunTask(t, srv, task.ID)
+			output, _ := resp["output"].(string)
+			if !strings.Contains(output, tc.wantOutput) {
+				t.Errorf("expected output to contain %q, got %q", tc.wantOutput, output)
 			}
 
 			// Verify schedule resumed — NextRun should be back in the future

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -520,8 +520,8 @@ func (s *MCPServer) handleRunTask(ctx context.Context, request *mcp.CallToolRequ
 	}
 
 	// Poll until a new result appears
-	timeout := time.After(120 * time.Second)
-	ticker := time.NewTicker(1 * time.Second)
+	timeout := time.After(s.config.Scheduler.DefaultTimeout)
+	ticker := time.NewTicker(s.config.Scheduler.PollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -530,7 +530,7 @@ func (s *MCPServer) handleRunTask(ctx context.Context, request *mcp.CallToolRequ
 			return nil, ctx.Err()
 		case <-timeout:
 			return createSuccessResponse(fmt.Sprintf(
-				"Task %s triggered but did not complete within 120s. Use get_task_result to check later.", taskID))
+				"Task %s triggered but did not complete within %s. Use get_task_result to check later.", taskID, s.config.Scheduler.DefaultTimeout))
 		case <-ticker.C:
 			if result, found := s.GetTaskResult(taskID); found && result.EndTime.After(beforeTime) {
 				return createResultResponse(result)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -499,9 +499,8 @@ func (s *MCPServer) handleDisableTask(_ context.Context, request *mcp.CallToolRe
 	return createTaskResponse(task)
 }
 
-// handleRunTask triggers immediate execution of a task
-func (s *MCPServer) handleRunTask(_ context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	// Extract task ID
+// handleRunTask triggers immediate execution of a task and waits for the result.
+func (s *MCPServer) handleRunTask(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	taskID, err := extractTaskIDParam(request)
 	if err != nil {
 		return nil, err
@@ -509,12 +508,35 @@ func (s *MCPServer) handleRunTask(_ context.Context, request *mcp.CallToolReques
 
 	s.logger.Debugf("Handling run_task request for task %s", taskID)
 
+	// Snapshot latest result time so we can detect the new one
+	var beforeTime time.Time
+	if latest, found := s.GetTaskResult(taskID); found {
+		beforeTime = latest.EndTime
+	}
+
 	// Trigger immediate execution
 	if err := s.scheduler.RunTaskNow(taskID); err != nil {
 		return nil, err
 	}
 
-	return createSuccessResponse(fmt.Sprintf("Task %s triggered for immediate execution", taskID))
+	// Poll until a new result appears
+	timeout := time.After(120 * time.Second)
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timeout:
+			return createSuccessResponse(fmt.Sprintf(
+				"Task %s triggered but did not complete within 120s. Use get_task_result to check later.", taskID))
+		case <-ticker.C:
+			if result, found := s.GetTaskResult(taskID); found && result.EndTime.After(beforeTime) {
+				return createResultResponse(result)
+			}
+		}
+	}
 }
 
 // handleGetTaskResult returns execution results for a task

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -68,7 +68,7 @@ func (s *MCPServer) registerToolsDeclarative() {
 		},
 		{
 			Name:        "run_task",
-			Description: "Immediately executes a task by ID. Use this to trigger on-demand tasks (created without a schedule) or to manually run a scheduled task outside its normal schedule. The task executes within ~1 second.",
+			Description: "Executes a task by ID, waits for completion, and returns the result. Use this to trigger on-demand tasks (created without a schedule) or to manually run a scheduled task outside its normal schedule.",
 			Handler:     s.handleRunTask,
 			Parameters:  TaskIDParams{},
 		},


### PR DESCRIPTION
## Summary
- `run_task` was fire-and-forget — it triggered execution and returned immediately with a "triggered" message
- AI agents calling `run_task` then `get_task_result` would get the **previous** run's stale result because the new one hadn't completed yet
- Now `handleRunTask` polls `GetTaskResult` until a new result appears and returns the actual result directly
- Poll timeout and interval use `DefaultTimeout` and `PollInterval` from config (not hardcoded)
- Tool description updated to reflect synchronous behavior
- Removed unused `waitForResult` test utility

## Test plan
- [x] `TestIntegration_RunTask` — verifies sync mode returns actual result content
- [x] `TestIntegration_OnDemandRunTaskLifecycle` — updated to check result from `mustRunTask` directly
- [x] `TestIntegration_ScheduledRunTaskResumesSchedule` — updated similarly
- [x] Full test suite passes: `go test ./...`
- [x] Lint clean: `go tool golangci-lint run`
- [x] Manual: WhatsApp → "Run hacker news task" → result matches latest in `~/.mcp-cron/results.db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)