### PR TITLE
feat: add HTTP/webhook task type (`add_http_task`)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ internal/
   command/             # Shell command executor (exec.CommandContext with timeout)
   config/              # Config structs, defaults, env var loading, validation
   errors/              # Typed errors: NotFound, AlreadyExists, InvalidInput, Internal
+  http/                # HTTP (webhook) task executor — issues a request, captures status/body/latency
   logging/             # Leveled logger (Debug/Info/Warn/Error/Fatal), file + stdout
   model/               # Core types: Task, Result, TaskType, TaskStatus, Executor, ResultStore interfaces
   scheduler/           # Poll-based DB scheduler (robfig/cron parser only), optimistic locking for multi-instance dedup
@@ -44,7 +45,7 @@ scripts/
 - **Vendor directory**: `vendor/` is gitignored — do NOT commit it. Dependencies are tracked via `go.mod` + `go.sum`; run `go mod vendor` locally to recreate.
 - **License header**: Every Go file starts with `// SPDX-License-Identifier: AGPL-3.0-only`
 - **Handler signature**: `func (s *MCPServer) handle<Name>(_ context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error)`
-- **Task types**: `shell_command` (runs a command) and `AI` (runs an LLM prompt)
+- **Task types**: `shell_command` (runs a command), `AI` (runs an LLM prompt), and `http` (issues an HTTP request — status → `exit_code`, body preview → `output`, latency → `duration`, URL persisted on the result row)
 - **Task statuses**: pending, running, completed, failed, disabled
 - **Storage**: In-memory read cache refreshed from SQLite on each poll tick; SQLite is the source of truth for task definitions and result history (`modernc.org/sqlite`, pure Go)
 - **Scheduling**: Poll-based — `next_run` column in `tasks` table, polled every `PollInterval` (default 1s). Optimistic locking (`UPDATE ... WHERE next_run = :current`) prevents duplicate execution across multiple instances sharing the same DB. Tasks can be **scheduled** (with a cron expression) or **on-demand** (no schedule, triggered via `run_task`).
@@ -57,7 +58,7 @@ scripts/
 
 ## MCP Tools Exposed
 
-list_tasks, get_task, get_task_result, query_task_result, add_task, add_ai_task, update_task, remove_task, run_task, enable_task, disable_task
+list_tasks, get_task, get_task_result, query_task_result, add_task, add_ai_task, add_http_task, update_task, remove_task, run_task, enable_task, disable_task
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -242,13 +242,14 @@ The server exposes several tools through the MCP protocol:
 2. `get_task` - Gets a specific task by ID
 3. `add_task` - Adds a new shell command task (provide `schedule` for recurring, or omit for on-demand)
 4. `add_ai_task` - Adds a new AI (LLM) task with a prompt (provide `schedule` for recurring, or omit for on-demand)
-5. `update_task` - Updates an existing task
-6. `remove_task` - Removes a task by ID
-7. `run_task` - Executes a task by ID, waits for completion, and returns the result (for on-demand tasks or ad-hoc runs of scheduled tasks)
-8. `enable_task` - Enables a task so it runs on its schedule or can be triggered via `run_task`
-9. `disable_task` - Disables a task so it stops running and cannot be triggered
-10. `get_task_result` - Gets execution results for a task (latest by default, or recent history with `limit`)
-11. `query_task_result` - Runs a read-only SQL query against the database (SELECT only, capped at 1000 rows)
+5. `add_http_task` - Adds a new HTTP (webhook) task that issues an HTTP request to a `url` (provide `schedule` for recurring, or omit for on-demand)
+6. `update_task` - Updates an existing task
+7. `remove_task` - Removes a task by ID
+8. `run_task` - Executes a task by ID, waits for completion, and returns the result (for on-demand tasks or ad-hoc runs of scheduled tasks)
+9. `enable_task` - Enables a task so it runs on its schedule or can be triggered via `run_task`
+10. `disable_task` - Disables a task so it stops running and cannot be triggered
+11. `get_task_result` - Gets execution results for a task (latest by default, or recent history with `limit`)
+12. `query_task_result` - Runs a read-only SQL query against the database (SELECT only, capped at 1000 rows)
 
 ### Task Format
 
@@ -272,9 +273,23 @@ Tasks have the following structure:
 }
 ```
 
-For shell command tasks, use the `command` field to specify the command to execute.
-For AI tasks, use the `prompt` field to specify what the AI should do.
-The `type` field can be either `shell_command` (default) or `AI`.
+The `type` field can be `shell_command` (default), `AI`, or `http`. The fields that apply depend on the type:
+
+- **`shell_command`** — `command`: the shell command to execute.
+- **`AI`** — `prompt`: what the AI should do.
+- **`http`** — `url` (required), `method` (defaults to `POST`), `headers` (JSON object of string→string), and `body` (request body string). Created via `add_http_task`.
+
+For HTTP tasks, the result row reuses the existing columns:
+
+| Result field | Meaning for HTTP tasks |
+|---|---|
+| `exit_code` | HTTP status code (0 if no response was received) |
+| `output`    | Response body preview (capped at 8 KiB, suffixed `... (truncated)`) |
+| `error`     | Transport error, build-request error, or `non-2xx status: N <reason>` |
+| `duration`  | Round-trip latency |
+| `url`       | The request URL |
+
+This keeps `query_task_result` queries uniform — e.g. `SELECT COUNT(*) FROM results WHERE task_id='x' AND exit_code >= 200 AND exit_code < 300` counts successful HTTP calls.
 
 **Scheduled vs on-demand tasks:**
 - **Scheduled**: Provide a `schedule` (cron expression) — the task runs automatically on that schedule.

--- a/cmd/mcp-cron/main.go
+++ b/cmd/mcp-cron/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jolks/mcp-cron/internal/agent"
 	"github.com/jolks/mcp-cron/internal/command"
 	"github.com/jolks/mcp-cron/internal/config"
+	httpexec "github.com/jolks/mcp-cron/internal/http"
 	"github.com/jolks/mcp-cron/internal/logging"
 	"github.com/jolks/mcp-cron/internal/model"
 	"github.com/jolks/mcp-cron/internal/scheduler"
@@ -149,6 +150,7 @@ type Application struct {
 	scheduler     *scheduler.Scheduler
 	cmdExecutor   *command.CommandExecutor
 	agentExecutor *agent.AgentExecutor
+	httpExecutor  *httpexec.HTTPExecutor
 	resultStore   model.ResultStore
 	server        *server.MCPServer
 	logger        *logging.Logger
@@ -174,11 +176,12 @@ func createApp(cfg *config.Config) (*Application, error) {
 	// Create components
 	cmdExec := command.NewCommandExecutor(resultStore, logger)
 	agentExec := agent.NewAgentExecutor(cfg, resultStore, logger)
+	httpExec := httpexec.NewHTTPExecutor(resultStore, logger)
 	sched := scheduler.NewScheduler(&cfg.Scheduler, logger)
 	sched.SetTaskStore(resultStore)
 
 	// Create the MCP server
-	mcpServer, err := server.NewMCPServer(cfg, sched, cmdExec, agentExec, resultStore, logger)
+	mcpServer, err := server.NewMCPServer(cfg, sched, cmdExec, agentExec, httpExec, resultStore, logger)
 	if err != nil {
 		_ = resultStore.Close()
 		return nil, err
@@ -189,6 +192,7 @@ func createApp(cfg *config.Config) (*Application, error) {
 		scheduler:     sched,
 		cmdExecutor:   cmdExec,
 		agentExecutor: agentExec,
+		httpExecutor:  httpExec,
 		resultStore:   resultStore,
 		server:        mcpServer,
 		logger:        logger,

--- a/cmd/mcp-cron/main_test.go
+++ b/cmd/mcp-cron/main_test.go
@@ -52,7 +52,7 @@ func TestMCPServerCreation(t *testing.T) {
 	agentExecutor := agent.NewAgentExecutor(cfg, nil, logger)
 
 	// Create the server with custom config
-	mcpServer, err := server.NewMCPServer(cfg, cronScheduler, commandExecutor, agentExecutor, nil, logger)
+	mcpServer, err := server.NewMCPServer(cfg, cronScheduler, commandExecutor, agentExecutor, nil, nil, logger)
 
 	if err != nil {
 		t.Fatalf("Failed to create MCP server: %v", err)
@@ -102,7 +102,7 @@ func TestSchedulerContinuesAfterTransportExit(t *testing.T) {
 	cmdExec := command.NewCommandExecutor(resultStore, logger)
 	agentExec := agent.NewAgentExecutor(cfg, resultStore, logger)
 
-	srv, err := server.NewMCPServer(cfg, sched, cmdExec, agentExec, resultStore, logger)
+	srv, err := server.NewMCPServer(cfg, sched, cmdExec, agentExec, nil, resultStore, logger)
 	if err != nil {
 		t.Fatalf("NewMCPServer: %v", err)
 	}

--- a/internal/http/executor.go
+++ b/internal/http/executor.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Package http implements the HTTP/webhook task executor.
+//
+// HTTP tasks issue an HTTP request and capture the response. The result
+// shape reuses model.Result without new fields: ExitCode holds the HTTP
+// status code (0 if no response), Output holds a body preview, Error
+// holds the transport error or a "non-2xx status N" message, Duration
+// captures the round-trip latency.
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	netHTTP "net/http"
+	"strings"
+	"time"
+
+	"github.com/jolks/mcp-cron/internal/logging"
+	"github.com/jolks/mcp-cron/internal/model"
+)
+
+// MaxBodyPreview caps the response body captured into Result.Output. Larger
+// responses are truncated with a "... (truncated)" suffix so the row stays
+// query-friendly.
+const MaxBodyPreview = 8 * 1024
+
+// HTTPExecutor handles executing HTTP tasks.
+type HTTPExecutor struct {
+	resultStore model.ResultStore
+	logger      *logging.Logger
+	client      *netHTTP.Client
+}
+
+// NewHTTPExecutor creates a new HTTP executor. The HTTP client uses the
+// per-request timeout passed to Execute, not a client-level one, so each
+// task can have its own deadline.
+func NewHTTPExecutor(store model.ResultStore, logger *logging.Logger) *HTTPExecutor {
+	return &HTTPExecutor{
+		resultStore: store,
+		logger:      logger,
+		client:      &netHTTP.Client{},
+	}
+}
+
+// Execute implements model.Executor.
+func (e *HTTPExecutor) Execute(ctx context.Context, task *model.Task, timeout time.Duration) error {
+	if task.ID == "" || task.URL == "" {
+		return fmt.Errorf("invalid task: missing ID or URL")
+	}
+
+	result := e.ExecuteHTTP(ctx, task, timeout)
+	if result.Error != "" {
+		return errors.New(result.Error)
+	}
+	return nil
+}
+
+// ExecuteHTTP performs the HTTP request and returns the resulting Result.
+func (e *HTTPExecutor) ExecuteHTTP(ctx context.Context, task *model.Task, timeout time.Duration) *model.Result {
+	method := strings.ToUpper(strings.TrimSpace(task.Method))
+	if method == "" {
+		method = netHTTP.MethodPost
+	}
+
+	result := &model.Result{
+		TaskID:    task.ID,
+		URL:       task.URL,
+		StartTime: time.Now(),
+	}
+
+	execCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var bodyReader io.Reader
+	if task.Body != "" {
+		bodyReader = strings.NewReader(task.Body)
+	}
+
+	req, err := netHTTP.NewRequestWithContext(execCtx, method, task.URL, bodyReader)
+	if err != nil {
+		result.EndTime = time.Now()
+		result.Duration = result.EndTime.Sub(result.StartTime).String()
+		result.Error = fmt.Sprintf("build request: %v", err)
+		model.PersistAndLogResult(e.resultStore, result, e.logger)
+		return result
+	}
+	for k, v := range task.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := e.client.Do(req)
+	result.EndTime = time.Now()
+	result.Duration = result.EndTime.Sub(result.StartTime).String()
+
+	if err != nil {
+		result.Error = err.Error()
+		model.PersistAndLogResult(e.resultStore, result, e.logger)
+		return result
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	result.ExitCode = resp.StatusCode
+
+	bodyBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, MaxBodyPreview+1))
+	if readErr != nil {
+		result.Error = fmt.Sprintf("read response body: %v", readErr)
+		model.PersistAndLogResult(e.resultStore, result, e.logger)
+		return result
+	}
+	if len(bodyBytes) > MaxBodyPreview {
+		result.Output = string(bodyBytes[:MaxBodyPreview]) + "... (truncated)"
+	} else {
+		result.Output = string(bodyBytes)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		result.Error = fmt.Sprintf("non-2xx status: %d %s", resp.StatusCode, resp.Status)
+	}
+
+	model.PersistAndLogResult(e.resultStore, result, e.logger)
+	return result
+}

--- a/internal/http/executor_test.go
+++ b/internal/http/executor_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+package http
+
+import (
+	"context"
+	"io"
+	netHTTP "net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jolks/mcp-cron/internal/logging"
+	"github.com/jolks/mcp-cron/internal/model"
+)
+
+func testLogger() *logging.Logger {
+	return logging.New(logging.Options{Output: io.Discard, Level: logging.Fatal})
+}
+
+func TestNewHTTPExecutor(t *testing.T) {
+	if NewHTTPExecutor(nil, testLogger()) == nil {
+		t.Fatal("NewHTTPExecutor returned nil")
+	}
+}
+
+func TestExecuteHTTP_Success(t *testing.T) {
+	var gotMethod, gotPath, gotAuth, gotBody string
+	srv := httptest.NewServer(netHTTP.HandlerFunc(func(w netHTTP.ResponseWriter, r *netHTTP.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(netHTTP.StatusOK)
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer srv.Close()
+
+	exec := NewHTTPExecutor(nil, testLogger())
+	task := &model.Task{
+		ID:      "task_http_1",
+		URL:     srv.URL + "/hook",
+		Method:  "POST",
+		Headers: map[string]string{"Authorization": "Bearer t"},
+		Body:    `{"hello":"world"}`,
+	}
+
+	result := exec.ExecuteHTTP(context.Background(), task, 5*time.Second)
+	if result.ExitCode != 200 {
+		t.Errorf("ExitCode = %d, want 200", result.ExitCode)
+	}
+	if result.Error != "" {
+		t.Errorf("Error = %q, want empty", result.Error)
+	}
+	if !strings.Contains(result.Output, `"ok":true`) {
+		t.Errorf("Output = %q, missing body", result.Output)
+	}
+	if result.URL != task.URL {
+		t.Errorf("URL = %q, want %q", result.URL, task.URL)
+	}
+	if gotMethod != "POST" || gotPath != "/hook" || gotAuth != "Bearer t" || gotBody != `{"hello":"world"}` {
+		t.Errorf("server saw method=%s path=%s auth=%s body=%s", gotMethod, gotPath, gotAuth, gotBody)
+	}
+}
+
+func TestExecuteHTTP_DefaultsToPOST(t *testing.T) {
+	var gotMethod string
+	srv := httptest.NewServer(netHTTP.HandlerFunc(func(w netHTTP.ResponseWriter, r *netHTTP.Request) {
+		gotMethod = r.Method
+		w.WriteHeader(netHTTP.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	exec := NewHTTPExecutor(nil, testLogger())
+	result := exec.ExecuteHTTP(context.Background(), &model.Task{
+		ID:  "task_http_default",
+		URL: srv.URL,
+	}, 5*time.Second)
+
+	if result.ExitCode != 204 {
+		t.Errorf("ExitCode = %d, want 204", result.ExitCode)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("server saw method=%s, want POST", gotMethod)
+	}
+}
+
+func TestExecuteHTTP_Non2xxBecomesError(t *testing.T) {
+	srv := httptest.NewServer(netHTTP.HandlerFunc(func(w netHTTP.ResponseWriter, _ *netHTTP.Request) {
+		w.WriteHeader(netHTTP.StatusInternalServerError)
+		_, _ = io.WriteString(w, "boom")
+	}))
+	defer srv.Close()
+
+	exec := NewHTTPExecutor(nil, testLogger())
+	result := exec.ExecuteHTTP(context.Background(), &model.Task{
+		ID: "task_http_500", URL: srv.URL, Method: "POST",
+	}, 5*time.Second)
+
+	if result.ExitCode != 500 {
+		t.Errorf("ExitCode = %d, want 500", result.ExitCode)
+	}
+	if !strings.Contains(result.Error, "non-2xx") {
+		t.Errorf("Error = %q, want 'non-2xx'", result.Error)
+	}
+	if result.Output != "boom" {
+		t.Errorf("Output = %q, want 'boom'", result.Output)
+	}
+}
+
+func TestExecuteHTTP_TransportErrorPopulatesError(t *testing.T) {
+	exec := NewHTTPExecutor(nil, testLogger())
+	// Bind to an invalid URL host so net/http fails fast at the transport layer.
+	result := exec.ExecuteHTTP(context.Background(), &model.Task{
+		ID: "task_http_bad", URL: "http://127.0.0.1:1/", Method: "POST",
+	}, 1*time.Second)
+
+	if result.Error == "" {
+		t.Error("expected transport error, got none")
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0 for transport error", result.ExitCode)
+	}
+}
+
+func TestExecuteHTTP_Timeout(t *testing.T) {
+	srv := httptest.NewServer(netHTTP.HandlerFunc(func(w netHTTP.ResponseWriter, _ *netHTTP.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(netHTTP.StatusOK)
+	}))
+	defer srv.Close()
+
+	exec := NewHTTPExecutor(nil, testLogger())
+	result := exec.ExecuteHTTP(context.Background(), &model.Task{
+		ID: "task_http_timeout", URL: srv.URL, Method: "GET",
+	}, 100*time.Millisecond)
+
+	if result.Error == "" {
+		t.Error("expected timeout error, got none")
+	}
+}
+
+func TestExecuteHTTP_BodyTruncation(t *testing.T) {
+	srv := httptest.NewServer(netHTTP.HandlerFunc(func(w netHTTP.ResponseWriter, _ *netHTTP.Request) {
+		// Write 2x MaxBodyPreview.
+		big := strings.Repeat("x", MaxBodyPreview*2)
+		_, _ = io.WriteString(w, big)
+	}))
+	defer srv.Close()
+
+	exec := NewHTTPExecutor(nil, testLogger())
+	result := exec.ExecuteHTTP(context.Background(), &model.Task{
+		ID: "task_http_big", URL: srv.URL, Method: "GET",
+	}, 5*time.Second)
+
+	if result.ExitCode != 200 {
+		t.Fatalf("ExitCode = %d, want 200", result.ExitCode)
+	}
+	if !strings.HasSuffix(result.Output, "... (truncated)") {
+		end := len(result.Output)
+		start := end - 30
+		if start < 0 {
+			start = 0
+		}
+		t.Errorf("Output should be truncated, got len=%d suffix=%q", end, result.Output[start:])
+	}
+}
+
+func TestExecute_ValidatesRequiredFields(t *testing.T) {
+	exec := NewHTTPExecutor(nil, testLogger())
+	if err := exec.Execute(context.Background(), &model.Task{ID: "x"}, time.Second); err == nil {
+		t.Error("expected error when URL missing")
+	}
+	if err := exec.Execute(context.Background(), &model.Task{URL: "http://example"}, time.Second); err == nil {
+		t.Error("expected error when ID missing")
+	}
+}
+
+func TestExecute_PersistsOnSuccessAndFailure(t *testing.T) {
+	store := &countingStore{}
+	srv := httptest.NewServer(netHTTP.HandlerFunc(func(w netHTTP.ResponseWriter, _ *netHTTP.Request) {
+		w.WriteHeader(netHTTP.StatusOK)
+	}))
+	defer srv.Close()
+
+	exec := NewHTTPExecutor(store, testLogger())
+	_ = exec.Execute(context.Background(), &model.Task{ID: "ok", URL: srv.URL}, 5*time.Second)
+	_ = exec.Execute(context.Background(), &model.Task{ID: "bad", URL: "http://127.0.0.1:1/"}, 500*time.Millisecond)
+
+	if got := atomic.LoadInt32(&store.saves); got != 2 {
+		t.Errorf("SaveResult called %d times, want 2", got)
+	}
+}
+
+// countingStore is a minimal model.ResultStore that counts SaveResult calls.
+type countingStore struct {
+	saves int32
+}
+
+func (c *countingStore) SaveResult(_ *model.Result) error {
+	atomic.AddInt32(&c.saves, 1)
+	return nil
+}
+func (c *countingStore) GetLatestResult(_ string) (*model.Result, error)         { return nil, nil }
+func (c *countingStore) GetResults(_ string, _ int) ([]*model.Result, error)     { return nil, nil }
+func (c *countingStore) QueryDB(_ context.Context, _ string) ([]map[string]interface{}, error) {
+	return nil, nil
+}
+func (c *countingStore) GetSchema() (string, error) { return "", nil }
+func (c *countingStore) Close() error               { return nil }

--- a/internal/model/task.go
+++ b/internal/model/task.go
@@ -16,6 +16,7 @@ type TaskStatus string
 const (
 	TypeShellCommand TaskType = "shell_command"
 	TypeAI           TaskType = "AI"
+	TypeHTTP         TaskType = "http"
 )
 
 // Task status constants
@@ -39,6 +40,10 @@ type Task struct {
 	Description string     `json:"description"`
 	Command     string     `json:"command,omitempty" description:"command for shell"`
 	Prompt      string     `json:"prompt,omitempty" description:"prompt to use for AI"`
+	URL         string     `json:"url,omitempty" description:"URL for HTTP tasks"`
+	Method      string     `json:"method,omitempty" description:"HTTP method for HTTP tasks (default POST)"`
+	Headers     map[string]string `json:"headers,omitempty" description:"HTTP request headers for HTTP tasks"`
+	Body        string     `json:"body,omitempty" description:"HTTP request body for HTTP tasks"`
 	Schedule    string     `json:"schedule"`
 	Enabled     bool       `json:"enabled"`
 	Type        TaskType   `json:"type"`
@@ -49,11 +54,16 @@ type Task struct {
 	UpdatedAt   time.Time  `json:"updatedAt,omitempty"`
 }
 
-// Result contains the results of a task execution
+// Result contains the results of a task execution.
+//
+// For HTTP tasks, ExitCode holds the HTTP status code (or 0 if no response
+// was received) and Output holds a body preview. Error is set when the
+// request failed at the transport level or returned a non-2xx status.
 type Result struct {
 	TaskID    string    `json:"task_id"`
 	Command   string    `json:"command,omitempty" description:"command for shell"`
 	Prompt    string    `json:"prompt,omitempty" description:"prompt to use for AI"`
+	URL       string    `json:"url,omitempty" description:"URL for HTTP tasks"`
 	Output    string    `json:"output"`
 	Error     string    `json:"error,omitempty"`
 	ExitCode  int       `json:"exit_code"`

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -150,3 +150,16 @@ func validateAITaskParams(name, prompt string) error {
 
 	return nil
 }
+
+// validateHTTPTaskParams validates the parameters specific to HTTP tasks
+func validateHTTPTaskParams(name, url string) error {
+	if err := validateTaskParams(name); err != nil {
+		return err
+	}
+
+	if url == "" {
+		return errors.InvalidInput("missing required field: url is required for http tasks")
+	}
+
+	return nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jolks/mcp-cron/internal/command"
 	"github.com/jolks/mcp-cron/internal/config"
 	"github.com/jolks/mcp-cron/internal/errors"
+	httpexec "github.com/jolks/mcp-cron/internal/http"
 	"github.com/jolks/mcp-cron/internal/logging"
 	"github.com/jolks/mcp-cron/internal/model"
 	"github.com/jolks/mcp-cron/internal/scheduler"
@@ -30,13 +31,17 @@ var osOpenFile = os.OpenFile
 
 // TaskParams holds parameters for various task operations
 type TaskParams struct {
-	ID          string `json:"id,omitempty" description:"task ID"`
-	Name        string `json:"name" description:"task name (required)"`
-	Schedule    string `json:"schedule,omitempty" description:"cron expression for recurring execution (e.g. '*/5 * * * *', '@hourly'). Omit to create an on-demand task triggered via run_task."`
-	Type        string `json:"type,omitempty" description:"task type: 'shell_command' or 'AI'"`
-	Command     string `json:"command,omitempty" description:"shell command to execute (required for shell_command tasks)"`
-	Description string `json:"description,omitempty" description:"task description"`
-	Enabled     bool   `json:"enabled,omitempty" description:"whether the task is enabled (defaults to false; set to true to activate immediately)"`
+	ID          string            `json:"id,omitempty" description:"task ID"`
+	Name        string            `json:"name" description:"task name (required)"`
+	Schedule    string            `json:"schedule,omitempty" description:"cron expression for recurring execution (e.g. '*/5 * * * *', '@hourly'). Omit to create an on-demand task triggered via run_task."`
+	Type        string            `json:"type,omitempty" description:"task type: 'shell_command', 'AI', or 'http'"`
+	Command     string            `json:"command,omitempty" description:"shell command to execute (required for shell_command tasks)"`
+	URL         string            `json:"url,omitempty" description:"URL to request (required for http tasks)"`
+	Method      string            `json:"method,omitempty" description:"HTTP method for http tasks (default POST)"`
+	Headers     map[string]string `json:"headers,omitempty" description:"HTTP request headers for http tasks"`
+	Body        string            `json:"body,omitempty" description:"HTTP request body for http tasks"`
+	Description string            `json:"description,omitempty" description:"task description"`
+	Enabled     bool              `json:"enabled,omitempty" description:"whether the task is enabled (defaults to false; set to true to activate immediately)"`
 }
 
 // TaskIDParams holds the ID parameter used by multiple handlers
@@ -66,6 +71,7 @@ type MCPServer struct {
 	scheduler      *scheduler.Scheduler
 	cmdExecutor    *command.CommandExecutor
 	agentExecutor  *agent.AgentExecutor
+	httpExecutor   *httpexec.HTTPExecutor
 	resultStore    model.ResultStore
 	server         *mcp.Server
 	httpServer     *http.Server
@@ -124,8 +130,12 @@ func CreateLogger(cfg *config.Config) (*logging.Logger, error) {
 	}), nil
 }
 
-// NewMCPServer creates a new MCP scheduler server
-func NewMCPServer(cfg *config.Config, scheduler *scheduler.Scheduler, cmdExecutor *command.CommandExecutor, agentExecutor *agent.AgentExecutor, resultStore model.ResultStore, logger *logging.Logger) (*MCPServer, error) {
+// NewMCPServer creates a new MCP scheduler server.
+//
+// httpExecutor is optional: passing nil disables the http task type at
+// execution time (handlers still accept add_http_task and the scheduler
+// will route it, but Execute will return an error).
+func NewMCPServer(cfg *config.Config, scheduler *scheduler.Scheduler, cmdExecutor *command.CommandExecutor, agentExecutor *agent.AgentExecutor, httpExecutor *httpexec.HTTPExecutor, resultStore model.ResultStore, logger *logging.Logger) (*MCPServer, error) {
 	// Create default config if not provided
 	if cfg == nil {
 		cfg = config.DefaultConfig()
@@ -152,6 +162,7 @@ func NewMCPServer(cfg *config.Config, scheduler *scheduler.Scheduler, cmdExecuto
 		scheduler:     scheduler,
 		cmdExecutor:   cmdExecutor,
 		agentExecutor: agentExecutor,
+		httpExecutor:  httpExecutor,
 		resultStore:   resultStore,
 		server:        mcpSrv,
 		address:       cfg.Server.Address,
@@ -340,6 +351,35 @@ func (s *MCPServer) handleAddAITask(_ context.Context, request *mcp.CallToolRequ
 	return createTaskResponse(task)
 }
 
+// handleAddHTTPTask adds a new HTTP/webhook task. Headers and body are optional;
+// method defaults to POST when omitted.
+func (s *MCPServer) handleAddHTTPTask(_ context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	var params TaskParams
+
+	if err := extractParams(request, &params); err != nil {
+		return nil, err
+	}
+
+	if err := validateHTTPTaskParams(params.Name, params.URL); err != nil {
+		return nil, err
+	}
+
+	s.logger.Debugf("Handling add_http_task request for task %s", params.Name)
+
+	task := createBaseTask(params.Name, params.Schedule, params.Description, params.Enabled)
+	task.Type = model.TypeHTTP
+	task.URL = params.URL
+	task.Method = params.Method
+	task.Headers = params.Headers
+	task.Body = params.Body
+
+	if err := s.scheduler.AddTask(task); err != nil {
+		return nil, err
+	}
+
+	return createTaskResponse(task)
+}
+
 // createBaseTask creates a base task with common fields initialized
 func createBaseTask(name, schedule, description string, enabled bool) *model.Task {
 	now := time.Now()
@@ -405,16 +445,31 @@ func updateTaskFields(task *model.Task, params AITaskParams, rawJSON []byte) {
 	if params.Prompt != "" {
 		task.Prompt = params.Prompt
 	}
+	if params.URL != "" {
+		task.URL = params.URL
+	}
+	if params.Method != "" {
+		task.Method = params.Method
+	}
+	if params.Headers != nil {
+		task.Headers = params.Headers
+	}
+	if params.Body != "" {
+		task.Body = params.Body
+	}
 	if params.Description != "" {
 		task.Description = params.Description
 	}
 
 	// Update task type if provided
 	if params.Type != "" {
-		if strings.EqualFold(params.Type, string(model.TypeAI)) {
+		switch {
+		case strings.EqualFold(params.Type, string(model.TypeAI)):
 			task.Type = model.TypeAI
-		} else if strings.EqualFold(params.Type, string(model.TypeShellCommand)) {
+		case strings.EqualFold(params.Type, string(model.TypeShellCommand)):
 			task.Type = model.TypeShellCommand
+		case strings.EqualFold(params.Type, string(model.TypeHTTP)):
+			task.Type = model.TypeHTTP
 		}
 	}
 
@@ -629,6 +684,13 @@ func (s *MCPServer) Execute(ctx context.Context, task *model.Task, timeout time.
 		// Use the agent executor for AI tasks
 		s.logger.Infof("Routing to AgentExecutor for AI task")
 		return s.agentExecutor.Execute(ctx, task, timeout)
+
+	case model.TypeHTTP:
+		s.logger.Infof("Routing to HTTPExecutor for HTTP task")
+		if s.httpExecutor == nil {
+			return fmt.Errorf("http executor not configured")
+		}
+		return s.httpExecutor.Execute(ctx, task, timeout)
 
 	case model.TypeShellCommand, "":
 		// Use the command executor for shell command tasks or when type is not specified

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -49,7 +49,7 @@ func TestNewMCPServer(t *testing.T) {
 	exec := command.NewCommandExecutor(nil, testLogger())
 	agentExec := agent.NewAgentExecutor(cfg, nil, testLogger())
 
-	server, err := NewMCPServer(cfg, sched, exec, agentExec, nil, testLogger())
+	server, err := NewMCPServer(cfg, sched, exec, agentExec, nil, nil, testLogger())
 	if err != nil {
 		t.Fatalf("Failed to create server with default config: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestNewMCPServerWithCustomConfig(t *testing.T) {
 	exec := command.NewCommandExecutor(nil, testLogger())
 	agentExec := agent.NewAgentExecutor(cfg, nil, testLogger())
 
-	server, err := NewMCPServer(cfg, sched, exec, agentExec, nil, testLogger())
+	server, err := NewMCPServer(cfg, sched, exec, agentExec, nil, nil, testLogger())
 	if err != nil {
 		t.Fatalf("Failed to create server with custom config: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestMCPServerStartStop(t *testing.T) {
 	exec := command.NewCommandExecutor(nil, testLogger())
 	agentExec := agent.NewAgentExecutor(cfg, nil, testLogger())
 
-	server, err := NewMCPServer(cfg, sched, exec, agentExec, nil, testLogger())
+	server, err := NewMCPServer(cfg, sched, exec, agentExec, nil, nil, testLogger())
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestTaskHandlers(t *testing.T) {
 	exec := command.NewCommandExecutor(nil, testLogger())
 	agentExec := agent.NewAgentExecutor(cfg, nil, testLogger())
 
-	server, err := NewMCPServer(cfg, sched, exec, agentExec, nil, testLogger())
+	server, err := NewMCPServer(cfg, sched, exec, agentExec, nil, nil, testLogger())
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestTaskCreationTimeFields(t *testing.T) {
 	exec := command.NewCommandExecutor(nil, testLogger())
 	agentExec := agent.NewAgentExecutor(cfg, nil, testLogger())
 
-	server, err := NewMCPServer(cfg, sched, exec, agentExec, nil, testLogger())
+	server, err := NewMCPServer(cfg, sched, exec, agentExec, nil, nil, testLogger())
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -55,6 +55,12 @@ func (s *MCPServer) registerToolsDeclarative() {
 			Parameters:  AITaskParams{},
 		},
 		{
+			Name:        "add_http_task",
+			Description: "Adds a new HTTP (webhook) task. Requires 'name' and 'url'. 'method' defaults to POST. 'headers' is a JSON object of string→string. 'body' is the request body. Provide 'schedule' for recurring execution or omit it to create an on-demand task triggered via run_task. The result captures HTTP status (as exit_code), response body preview (as output), and round-trip latency (as duration).",
+			Handler:     s.handleAddHTTPTask,
+			Parameters:  TaskParams{},
+		},
+		{
 			Name:        "update_task",
 			Description: "Updates an existing task. Requires 'id'. Only provided fields are updated; omitted fields remain unchanged.",
 			Handler:     s.handleUpdateTask,
@@ -201,6 +207,10 @@ func goTypeToJSONType(t reflect.Type) string {
 		return "integer"
 	case reflect.Float32, reflect.Float64:
 		return "number"
+	case reflect.Map:
+		return "object"
+	case reflect.Slice, reflect.Array:
+		return "array"
 	default:
 		return "string"
 	}

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -62,6 +62,24 @@ var migrations = []migration{
 			return err
 		},
 	},
+	{
+		version: 4,
+		up: func(tx *sql.Tx) error {
+			stmts := []string{
+				`ALTER TABLE tasks ADD COLUMN url TEXT DEFAULT ''`,
+				`ALTER TABLE tasks ADD COLUMN method TEXT DEFAULT ''`,
+				`ALTER TABLE tasks ADD COLUMN headers_json TEXT DEFAULT ''`,
+				`ALTER TABLE tasks ADD COLUMN body TEXT DEFAULT ''`,
+				`ALTER TABLE results ADD COLUMN url TEXT DEFAULT ''`,
+			}
+			for _, s := range stmts {
+				if _, err := tx.Exec(s); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	},
 }
 
 // runMigrations ensures the schema_version table exists and runs any pending migrations.

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -4,6 +4,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -59,11 +60,12 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 // SaveResult persists a task execution result.
 func (s *SQLiteStore) SaveResult(result *model.Result) error {
 	_, err := s.db.Exec(`
-		INSERT INTO results (task_id, command, prompt, output, error, exit_code, start_time, end_time, duration)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		INSERT INTO results (task_id, command, prompt, url, output, error, exit_code, start_time, end_time, duration)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		result.TaskID,
 		result.Command,
 		result.Prompt,
+		result.URL,
 		result.Output,
 		result.Error,
 		result.ExitCode,
@@ -101,7 +103,7 @@ func (s *SQLiteStore) GetResults(taskID string, limit int) ([]*model.Result, err
 	}
 
 	rows, err := s.db.Query(`
-		SELECT task_id, command, prompt, output, error, exit_code, start_time, end_time, duration
+		SELECT task_id, command, prompt, url, output, error, exit_code, start_time, end_time, duration
 		FROM results
 		WHERE task_id = ?
 		ORDER BY start_time DESC
@@ -116,7 +118,7 @@ func (s *SQLiteStore) GetResults(taskID string, limit int) ([]*model.Result, err
 		var r model.Result
 		var startStr, endStr string
 		if err := rows.Scan(
-			&r.TaskID, &r.Command, &r.Prompt, &r.Output,
+			&r.TaskID, &r.Command, &r.Prompt, &r.URL, &r.Output,
 			&r.Error, &r.ExitCode, &startStr, &endStr, &r.Duration,
 		); err != nil {
 			return nil, fmt.Errorf("scan result row: %w", err)
@@ -138,15 +140,23 @@ func (s *SQLiteStore) SaveTask(task *model.Task) error {
 	if !task.NextRun.IsZero() {
 		nextRun = task.NextRun.Format(timeFormat)
 	}
-	_, err := s.db.Exec(`
-		INSERT INTO tasks (id, name, description, type, command, prompt, schedule, enabled, created_at, updated_at, next_run)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	headersJSON, err := marshalHeaders(task.Headers)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(`
+		INSERT INTO tasks (id, name, description, type, command, prompt, url, method, headers_json, body, schedule, enabled, created_at, updated_at, next_run)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		task.ID,
 		task.Name,
 		task.Description,
 		task.Type,
 		task.Command,
 		task.Prompt,
+		task.URL,
+		task.Method,
+		headersJSON,
+		task.Body,
 		task.Schedule,
 		boolToInt(task.Enabled),
 		task.CreatedAt.Format(timeFormat),
@@ -165,14 +175,22 @@ func (s *SQLiteStore) UpdateTask(task *model.Task) error {
 	if !task.NextRun.IsZero() {
 		nextRun = task.NextRun.Format(timeFormat)
 	}
+	headersJSON, err := marshalHeaders(task.Headers)
+	if err != nil {
+		return err
+	}
 	result, err := s.db.Exec(`
-		UPDATE tasks SET name=?, description=?, type=?, command=?, prompt=?, schedule=?, enabled=?, updated_at=?, next_run=?
+		UPDATE tasks SET name=?, description=?, type=?, command=?, prompt=?, url=?, method=?, headers_json=?, body=?, schedule=?, enabled=?, updated_at=?, next_run=?
 		WHERE id=?`,
 		task.Name,
 		task.Description,
 		task.Type,
 		task.Command,
 		task.Prompt,
+		task.URL,
+		task.Method,
+		headersJSON,
+		task.Body,
 		task.Schedule,
 		boolToInt(task.Enabled),
 		task.UpdatedAt.Format(timeFormat),
@@ -205,10 +223,11 @@ func (s *SQLiteStore) DeleteTask(taskID string) error {
 func scanTask(rows *sql.Rows) (*model.Task, error) {
 	var t model.Task
 	var enabled int
-	var createdStr, updatedStr, nextRunStr string
+	var createdStr, updatedStr, nextRunStr, headersJSON string
 	if err := rows.Scan(
 		&t.ID, &t.Name, &t.Description, &t.Type,
-		&t.Command, &t.Prompt, &t.Schedule,
+		&t.Command, &t.Prompt, &t.URL, &t.Method, &headersJSON, &t.Body,
+		&t.Schedule,
 		&enabled, &createdStr, &updatedStr, &nextRunStr,
 	); err != nil {
 		return nil, fmt.Errorf("scan task row: %w", err)
@@ -219,6 +238,9 @@ func scanTask(rows *sql.Rows) (*model.Task, error) {
 	if nextRunStr != "" {
 		t.NextRun, _ = time.Parse(timeFormat, nextRunStr)
 	}
+	if headersJSON != "" {
+		_ = json.Unmarshal([]byte(headersJSON), &t.Headers)
+	}
 	t.Status = model.StatusPending
 	return &t, nil
 }
@@ -226,7 +248,7 @@ func scanTask(rows *sql.Rows) (*model.Task, error) {
 // LoadTasks returns all persisted task definitions.
 func (s *SQLiteStore) LoadTasks() ([]*model.Task, error) {
 	rows, err := s.db.Query(`
-		SELECT id, name, description, type, command, prompt, schedule, enabled, created_at, updated_at, next_run
+		SELECT id, name, description, type, command, prompt, url, method, headers_json, body, schedule, enabled, created_at, updated_at, next_run
 		FROM tasks`)
 	if err != nil {
 		return nil, fmt.Errorf("query tasks: %w", err)
@@ -253,7 +275,7 @@ func (s *SQLiteStore) LoadTasks() ([]*model.Task, error) {
 // GetDueTasks returns all enabled tasks whose next_run is at or before the given time.
 func (s *SQLiteStore) GetDueTasks(now time.Time) ([]*model.Task, error) {
 	rows, err := s.db.Query(`
-		SELECT id, name, description, type, command, prompt, schedule, enabled, created_at, updated_at, next_run
+		SELECT id, name, description, type, command, prompt, url, method, headers_json, body, schedule, enabled, created_at, updated_at, next_run
 		FROM tasks
 		WHERE enabled = 1 AND next_run != '' AND next_run <= ?`,
 		now.Format(timeFormat))
@@ -410,6 +432,19 @@ func boolToInt(b bool) int {
 		return 1
 	}
 	return 0
+}
+
+// marshalHeaders serializes a header map as a JSON object string for storage.
+// Returns "" for nil/empty maps so empty rows stay readable in sqlite_master dumps.
+func marshalHeaders(h map[string]string) (string, error) {
+	if len(h) == 0 {
+		return "", nil
+	}
+	b, err := json.Marshal(h)
+	if err != nil {
+		return "", fmt.Errorf("marshal headers: %w", err)
+	}
+	return string(b), nil
 }
 
 // Close closes the underlying database connection.

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -305,6 +305,86 @@ func TestSaveAndLoadAITask(t *testing.T) {
 	}
 }
 
+func TestSaveAndLoadHTTPTask(t *testing.T) {
+	s := newTestStore(t)
+
+	now := time.Now().Truncate(time.Microsecond)
+	task := &model.Task{
+		ID:       "http-task-1",
+		Name:     "Webhook Task",
+		Type:     "http",
+		URL:      "https://example.com/hook",
+		Method:   "POST",
+		Headers:  map[string]string{"Authorization": "Bearer secret", "X-Source": "mcp-cron"},
+		Body:     `{"hello":"world"}`,
+		Schedule: "@hourly",
+		Enabled:  true,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := s.SaveTask(task); err != nil {
+		t.Fatalf("SaveTask: %v", err)
+	}
+
+	tasks, err := s.LoadTasks()
+	if err != nil {
+		t.Fatalf("LoadTasks: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+
+	got := tasks[0]
+	if got.Type != "http" {
+		t.Errorf("Type = %q, want %q", got.Type, "http")
+	}
+	if got.URL != task.URL {
+		t.Errorf("URL = %q, want %q", got.URL, task.URL)
+	}
+	if got.Method != "POST" {
+		t.Errorf("Method = %q, want %q", got.Method, "POST")
+	}
+	if got.Body != task.Body {
+		t.Errorf("Body = %q, want %q", got.Body, task.Body)
+	}
+	if got.Headers["Authorization"] != "Bearer secret" || got.Headers["X-Source"] != "mcp-cron" {
+		t.Errorf("Headers round-trip failed: %#v", got.Headers)
+	}
+}
+
+func TestSaveAndGetHTTPResult(t *testing.T) {
+	s := newTestStore(t)
+
+	now := time.Now().Truncate(time.Microsecond)
+	r := &model.Result{
+		TaskID:    "http-task-1",
+		URL:       "https://example.com/hook",
+		Output:    `{"ok":true}`,
+		ExitCode:  200,
+		StartTime: now,
+		EndTime:   now.Add(120 * time.Millisecond),
+		Duration:  "120ms",
+	}
+
+	if err := s.SaveResult(r); err != nil {
+		t.Fatalf("SaveResult: %v", err)
+	}
+	got, err := s.GetLatestResult("http-task-1")
+	if err != nil {
+		t.Fatalf("GetLatestResult: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected result, got nil")
+	}
+	if got.URL != r.URL {
+		t.Errorf("URL = %q, want %q", got.URL, r.URL)
+	}
+	if got.ExitCode != 200 {
+		t.Errorf("ExitCode = %d, want 200", got.ExitCode)
+	}
+}
+
 func TestUpdateTaskStore(t *testing.T) {
 	s := newTestStore(t)
 


### PR DESCRIPTION
Implements the proposal from #19. No rush on review — happy to adjust naming, scope, or behavior to your taste, or close this if you'd rather take a different direction.

## What this adds

A third executor sibling alongside `internal/command/` and `internal/agent/` that issues an HTTP request and captures the response. Use case: agent runtimes that need to schedule a future callback (POST back into the agent's API) without shelling out to `curl`.

```
add_http_task(name, url, method?, headers?, body?, schedule?, enabled?)
```

`method` defaults to POST. `schedule` omitted = on-demand task triggered by `run_task`.

## Result shape (no new columns on `results` beyond `url`)

| Result field | Meaning for HTTP tasks |
|---|---|
| `exit_code` | HTTP status code (0 if no response received) |
| `output`    | Response body preview (capped at 8 KiB, suffixed `... (truncated)`) |
| `error`     | Transport error, build-request error, or `non-2xx status: N <reason>` |
| `duration`  | Round-trip latency |
| `url`       | The request URL (new column) |

Reusing `exit_code` for HTTP status keeps `query_task_result` queries uniform — e.g. `SELECT COUNT(*) FROM results WHERE task_id='x' AND exit_code >= 200 AND exit_code < 300`.

## Files (12 changed, +601/-32)

**New**
- `internal/http/executor.go` — `HTTPExecutor`. Per-request timeout via `context.WithTimeout`. Body preview cap. Transport errors and non-2xx persisted with `Error` set.
- `internal/http/executor_test.go` — 8 tests via `httptest.Server`: success, default-method, non-2xx, transport error, timeout, body truncation, validation, persistence-on-success-and-failure.

**Modified**
- `internal/model/task.go` — `TypeHTTP` const + `URL`/`Method`/`Headers`/`Body` fields on `Task`, `URL` on `Result`.
- `internal/store/migrations.go` — schema migration v4: `ALTER TABLE tasks ADD COLUMN url/method/headers_json/body`; `ALTER TABLE results ADD COLUMN url`. Backfills with empty strings.
- `internal/store/sqlite.go` — `SaveTask`/`UpdateTask`/`scanTask`/`LoadTasks`/`GetDueTasks`/`SaveResult`/`GetResults` updated; `headers` round-trips as JSON in `headers_json`.
- `internal/store/sqlite_test.go` — 2 new round-trip tests (HTTP task + HTTP result).
- `internal/server/server.go` — `httpExecutor` field, `NewMCPServer` signature, dispatch case in `Execute`. `TaskParams` extended with `URL`/`Method`/`Headers`/`Body` so `update_task` picks them up too. New `handleAddHTTPTask`.
- `internal/server/tools.go` — `add_http_task` registration. `goTypeToJSONType` now maps `map → object` and `slice → array` so `headers` renders correctly in the tool schema (previously fell through to `string`).
- `internal/server/handlers.go` — `validateHTTPTaskParams` helper.
- `internal/server/server_test.go` — `NewMCPServer` call sites updated.
- `cmd/mcp-cron/main.go` + `main_test.go` — wire the new executor.

## Conventions

- SPDX-License-Identifier: AGPL-3.0-only on all new files.
- Logger via `*logging.Logger` (no `fmt.Printf`).
- Handler signature matches existing pattern.
- `golangci-lint` clean (`go tool golangci-lint run` → 0 issues).
- `go test ./... -cover` green, including all pre-existing tests.

## What's intentionally NOT in scope here

- No retry on 5xx — caller can build that into the schedule cadence, or it can be a follow-up.
- No header redaction in `query_task_result` output — headers aren't surfaced in results today, only the URL/body-preview/status/error. If you want headers persisted on the result row, easy follow-up.
- No nullable `Headers` distinction between "omit" vs "clear" on update — `update_task` treats a present `headers` value as "set".

## Verification

```
$ go build ./...           # clean
$ go test ./... -cover     # all green
$ go tool golangci-lint run
0 issues.
```

Happy to rework, split, or close — your call.